### PR TITLE
Enable install rules when OCV is disabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,39 +190,37 @@ ENDIF()
 set(DEF_INSTALL_CMAKE_DIR lib/cmake/klepsydrarobotics)
 set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
 
-if (KPSR_WITH_OCV)
-  # Make relative paths absolute (needed later on)
-  foreach(p LIB BIN INCLUDE CMAKE)
-    set(var INSTALL_${p}_DIR)
-    if(NOT IS_ABSOLUTE "${${var}}")
-      set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
-    endif()
-  endforeach()
+# Make relative paths absolute (needed later on)
+foreach(p LIB BIN INCLUDE CMAKE)
+  set(var INSTALL_${p}_DIR)
+  if(NOT IS_ABSOLUTE "${${var}}")
+    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  endif()
+endforeach()
 
-  list (APPEND EXPORT_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR})
-  export(TARGETS ${CORE_EXPORT_TARGETS} ${DDS_EXPORT_TARGETS} ${ZMQ_EXPORT_TARGETS} FILE "${PROJECT_BINARY_DIR}/KlepsydraRoboticsTargets.cmake")
+list (APPEND EXPORT_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+export(TARGETS ${CORE_EXPORT_TARGETS} ${DDS_EXPORT_TARGETS} ${ZMQ_EXPORT_TARGETS} FILE "${PROJECT_BINARY_DIR}/KlepsydraRoboticsTargets.cmake")
 
-  # Export the package for use from the build-tree
-  # (this registers the build-tree with a global CMake-registry)
-  export(PACKAGE robotics)
+# Export the package for use from the build-tree
+# (this registers the build-tree with a global CMake-registry)
+export(PACKAGE robotics)
 
-  # Create the KlepsydraRoboticsConfig.cmake and KlepsydraRoboticsConfigVersion files
-  configure_file(KlepsydraRoboticsConfig.cmake.in
-    "${PROJECT_BINARY_DIR}/KlepsydraRoboticsConfig.cmake" @ONLY)
+# Create the KlepsydraRoboticsConfig.cmake and KlepsydraRoboticsConfigVersion files
+configure_file(KlepsydraRoboticsConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/KlepsydraRoboticsConfig.cmake" @ONLY)
 
-  configure_file(KlepsydraRoboticsConfig.cmake.in
-    "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/KlepsydraRoboticsConfig.cmake" @ONLY)
-  # ... for both
-  configure_file(KlepsydraRoboticsConfigVersion.cmake.in
-    "${PROJECT_BINARY_DIR}/KlepsydraRoboticsConfigVersion.cmake" @ONLY)
+configure_file(KlepsydraRoboticsConfig.cmake.in
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/KlepsydraRoboticsConfig.cmake" @ONLY)
+# ... for both
+configure_file(KlepsydraRoboticsConfigVersion.cmake.in
+  "${PROJECT_BINARY_DIR}/KlepsydraRoboticsConfigVersion.cmake" @ONLY)
 
-  # Install the KlepsydraRoboticsConfig.cmake and KlepsydraRoboticsConfigVersion.cmake
-  install(FILES
-    "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/KlepsydraRoboticsConfig.cmake"
-    "${PROJECT_BINARY_DIR}/KlepsydraRoboticsConfigVersion.cmake"
-    DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+# Install the KlepsydraRoboticsConfig.cmake and KlepsydraRoboticsConfigVersion.cmake
+install(FILES
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/KlepsydraRoboticsConfig.cmake"
+  "${PROJECT_BINARY_DIR}/KlepsydraRoboticsConfigVersion.cmake"
+  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
 
-  # Install the export set for use with the install-tree
-  install(EXPORT KlepsydraRoboticsTargets DESTINATION
-    "${INSTALL_CMAKE_DIR}" COMPONENT dev)
-endif()
+# Install the export set for use with the install-tree
+install(EXPORT KlepsydraRoboticsTargets DESTINATION
+  "${INSTALL_CMAKE_DIR}" COMPONENT dev)


### PR DESCRIPTION
With this fix, the package is still installed correctly if OpenCV
support is disabled.