### PR TITLE
update cmake, fix Tests, ignore vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Config.cmake
 **/**/config.h
 gen/**
 gen
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ if (HAS_CXX11)
 endif()
 
 if (NOT APPLE)
+    set(CMAKE_INSTALL_RPATH $ORIGIN)
     check_cxx_compiler_flag(-Wl,--no-undefined HAS_NO_UNDEFINED)
     if (HAS_NO_UNDEFINED)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-undefined")

--- a/vision_ocv/tests/mem_vision_ocv_tests/src/image_multiplexer_vision_ocv_test.cpp
+++ b/vision_ocv/tests/mem_vision_ocv_tests/src/image_multiplexer_vision_ocv_test.cpp
@@ -58,6 +58,13 @@ TEST(HPVisionTest, HPVisionTest)
         slowReadService.execute();
     }
 
+    int numAttempts = 10;
+    for (int i = 0; i < numAttempts; i++) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (simpleReadService.receivedEvents == 50)
+            break;
+    }
+
     writeService.stop();
     simpleReadService.stop();
     slowReadService.stop();


### PR DESCRIPTION
Set CMAKE_INSTALL_RPATH variable in CMakeLists

Fix image multiplexer vision test to be able to run on slower PC

Ignore .vscode folder